### PR TITLE
Moving most println! statements to debug! statements

### DIFF
--- a/src/dao.rs
+++ b/src/dao.rs
@@ -354,9 +354,9 @@ pub type ParseError = String;
 
 impl Dao{
 	pub fn from_str(s: &str)->Result<Vec<Self>, ParseError>{
-		println!("parsing multiple records from json");
+		debug!("parsing multiple records from json");
 		let json: Json = Json::from_str(s).unwrap();
-		println!("from str json: {:#?}", json);
+		debug!("from str json: {:#?}", json);
 		match json{
 			Json::Array(array) => {
 				let mut dao_list = vec![];
@@ -406,7 +406,7 @@ impl Dao{
 	pub fn from_str_one(s: &str)->Result<Self, ()>{
 		let json: Json = Json::from_str(s).unwrap();
 		// then convert this map to Value
-		println!("from str: {:#?}", json);
+		debug!("from str: {:#?}", json);
 		let values = Self::json_object_to_btree(json);
 		Ok(Dao{
 			values: values

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,9 @@ extern crate r2d2_postgres;
 #[cfg(feature = "sqlite")]
 extern crate r2d2_sqlite;
 extern crate time;
+#[macro_use]
+extern crate log;
+
 
 
 //pub mod em;

--- a/src/platform/mysql.rs
+++ b/src/platform/mysql.rs
@@ -132,7 +132,7 @@ impl Mysql{
                                 ColumnType::MYSQL_TYPE_TIMESTAMP => {
                                     let v: Timespec = FromValue::from_value(value.clone());
                                     let t = NaiveDateTime::from_timestamp(v.sec, v.nsec as u32);
-                                    println!("time: {}",t);
+                                    debug!("time: {}",t);
                                     let t2 = DateTime::from_utc(t, UTC);
                                     Value::DateTime(t2)
                                 },
@@ -443,14 +443,14 @@ impl Database for Mysql {
     }
 
     fn execute_sql_with_return(&self, sql: &str, params: &[Value]) -> Result<Vec<Dao>, DbError> {
-        println!("SQL: \n{}", sql);
-        println!("param: {:?}", params);
+        debug!("SQL: \n{}", sql);
+        debug!("param: {:?}", params);
         assert!(self.pool.is_some());
         let mut stmt = try!(self.get_prepared_statement(sql));
         let mut columns = vec![];
         for col in stmt.columns_ref().unwrap() {
             let column_name = String::from_utf8(col.name.clone()).unwrap();
-            println!("column type: {:?}", col.column_type);
+            debug!("column type: {:?}", col.column_type);
             columns.push( (column_name, col.column_type) );
         }
         let mut daos = vec![];
@@ -486,8 +486,8 @@ impl Database for Mysql {
     /// returns only the number of affected records or errors
     /// can be used with DDL operations (CREATE, DELETE, ALTER, DROP)
     fn execute_sql(&self, sql: &str, params: &[Value]) -> Result<usize, DbError> {
-        println!("SQL: \n{}", sql);
-        println!("param: {:?}", params);
+        debug!("SQL: \n{}", sql);
+        debug!("param: {:?}", params);
         let to_sql_types = Mysql::from_rust_type_tosql(params);
         assert!(self.pool.is_some());
         let result = try!(self.pool.as_ref().unwrap().prep_exec(sql, &to_sql_types));
@@ -532,7 +532,7 @@ impl DatabaseDDL for Mysql{
     fn create_table(&self, table: &Table) {
         let frag = self.build_create_table(table);
         match self.execute_sql(&frag.sql, &vec![]) {
-            Ok(_) => println!("created table.."),
+            Ok(_) => debug!("created table.."),
             Err(e) => panic!("table not created {}", e),
         }
     }

--- a/src/platform/postgres.rs
+++ b/src/platform/postgres.rs
@@ -482,8 +482,8 @@ impl Database for Postgres {
     }
 
     fn execute_sql_with_return(&self, sql: &str, params: &[Value]) -> Result<Vec<Dao>, DbError> {
-        println!("SQL: \n{}", sql);
-        println!("param: {:?}", params);
+        debug!("SQL: \n{}", sql);
+        debug!("param: {:?}", params);
         let conn = self.get_connection();
         let stmt = try!(conn.prepare(sql));
         let mut daos = vec![];
@@ -509,8 +509,8 @@ impl Database for Postgres {
     /// returns only the number of affected records or errors
     /// can be used with DDL operations (CREATE, DELETE, ALTER, DROP)
     fn execute_sql(&self, sql: &str, params: &[Value]) -> Result<usize, DbError> {
-        println!("SQL: \n{}", sql);
-        println!("param: {:?}", params);
+        debug!("SQL: \n{}", sql);
+        debug!("param: {:?}", params);
         let to_sql_types = self.from_rust_type_tosql(params);
         let conn = self.get_connection();
         let result = try!(conn.execute(sql, &to_sql_types));

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -69,7 +69,7 @@ impl Deref for Platform{
 	type Target = Database;
 
 	fn deref(&self)->&Self::Target{
-		println!("using deref...");
+		debug!("using deref...");
         match *self {
             Platform::Postgres(ref pg) => pg,
             #[cfg(feature = "sqlite")]
@@ -104,7 +104,7 @@ impl ManagedPool {
                 match platform {
                     "postgres" => {
                         let manager = try!(PostgresConnectionManager::new(url, SslMode::None));
-                        println!("Creating a connection with a pool size of {}", pool_size);
+                        debug!("Creating a connection with a pool size of {}", pool_size);
                         let config = Config::builder().pool_size(pool_size as u32).build();
                         let pool = try!(Pool::new(config, manager));
                         Ok(ManagedPool::Postgres(pool))

--- a/src/query/table_name.rs
+++ b/src/query/table_name.rs
@@ -80,7 +80,7 @@ impl <'a>ToTableName for &'a str {
 impl <F>ToTableName for F where F: Fn() -> Table{
 	fn to_table_name(&self) -> TableName{
 		let table = self();
-		println!("table: {:?}", table);
+		debug!("table: {:?}", table);
 		table.to_table_name()
 	}
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -73,7 +73,7 @@ impl Column {
     ///some column names may be a rust reserve keyword, so have to correct them
     pub fn corrected_name(&self) -> String {
         if Self::is_keyword(&self.name) {
-            println!("Warning: {} is rust reserved keyword", self.name);
+            warn!("Warning: {} is rust reserved keyword", self.name);
             return format!("{}_", self.name);
         }
         self.name.to_owned()


### PR DESCRIPTION
I took most println! statements in the lib code and turned them into debug! statements.
I left an println here and there, in places where I wasn't sure, like when there were error messages.  They are probably better served by an 'error!' or something else, but decided against replacing those.

As part of this, I upgraded the log crate, and also removed the env_log crate, since libraries should only use the log crate, while library using projects determine which log backend to use, according to rust doc:

https://doc.rust-lang.org/log/log/index.html#in-libraries

Let me know if these make sense, or if this is not desired.
